### PR TITLE
Fix sources jar including compiled classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,6 @@ processResources {
 
 task sourcesJar(type: Jar) {
     from sourceSets.main.allSource
-    from sourceSets.main.output
     classifier = 'sources'
 }
 


### PR DESCRIPTION
There is also something up with your jenkins build server.
It seems to also include some pretty old (1.7.10) compiled classes (as well as empty folders). Switching it to `clean build` *might* fix it (but will break incremental builds -- which may not be a good idea on CI anyway)