### PR TITLE
Added Workers mod compatibility

### DIFF
--- a/common/src/main/resources/data/armourers_workshop/skin/profiles/npc.json
+++ b/common/src/main/resources/data/armourers_workshop/skin/profiles/npc.json
@@ -40,6 +40,15 @@
     "recruits:nomad",
     "recruits:recruit",
     "recruits:recruit_shieldman",
+    "workers:miner",
+    "workers:lumberjack",
+    "workers:fisherman",
+    "workers:merchant",
+    "workers:shepherd",
+    "workers:swineherd",
+    "workers:cattle_farmer",
+    "workers:chicken_farmer",
+    "workers:farmer",
     "taterzens:npc",
     "modulargolems:humanoid_golem"
   ]


### PR DESCRIPTION
I noticed the mod already is compatible with [Recruits](https://modrinth.com/mod/villager-recruits) mod, but [Workers](https://modrinth.com/mod/villager-workers) is not there (by the way they're made by the same author)
I'm opening this simple PR to add the compatibility to Workers professions. 

![image](https://github.com/user-attachments/assets/b5b3af1f-8f1b-4cae-9844-df90485372c7)
