### PR TITLE
Exposing skin texture

### DIFF
--- a/src/main/java/moe/plushie/armourers_workshop/client/render/EntityTextureInfo.java
+++ b/src/main/java/moe/plushie/armourers_workshop/client/render/EntityTextureInfo.java
@@ -2,7 +2,12 @@ package moe.plushie.armourers_workshop.client.render;
 
 import java.awt.Point;
 import java.awt.image.BufferedImage;
-import java.io.IOException;
+import java.io.*;
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import moe.plushie.armourers_workshop.api.common.IExtraColours;
 import moe.plushie.armourers_workshop.api.common.painting.IPaintType;
@@ -22,9 +27,13 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.AbstractTexture;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.client.renderer.texture.TextureUtil;
-import net.minecraft.client.resources.DefaultPlayerSkin;
-import net.minecraft.client.resources.IResourceManager;
+import net.minecraft.client.resources.*;
+import net.minecraft.client.resources.data.IMetadataSection;
+import net.minecraft.client.resources.data.MetadataSerializer;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+
+import javax.imageio.ImageIO;
 
 public class EntityTextureInfo {
 
@@ -345,6 +354,7 @@ public class EntityTextureInfo {
         SkinTextureObject sto = new SkinTextureObject(bufferedEntitySkinnedImage);
         replacementTexture = new ResourceLocation(LibModInfo.ID.toLowerCase(), String.valueOf(bufferedEntitySkinnedImage.hashCode()));
         renderEngine.loadTexture(replacementTexture, sto);
+        exposeTexture(replacementTexture, bufferedEntitySkinnedImage);
     }
 
     public ResourceLocation preRender() {
@@ -376,6 +386,88 @@ public class EntityTextureInfo {
         public void loadTexture(IResourceManager resourceManager) throws IOException {
             getGlTextureId();
             TextureUtil.uploadTextureImage(glTextureId, texture);
+        }
+    }
+
+    private void exposeTexture(ResourceLocation location, BufferedImage texture) {
+        try {
+            Field resourceManagerField = Minecraft.class.getDeclaredField("field_110451_am"); // field_110451_am mcResourceManager
+            resourceManagerField.setAccessible(true);
+            SimpleReloadableResourceManager resourceManager = (SimpleReloadableResourceManager) resourceManagerField.get(Minecraft.getMinecraft());
+            // Add our custom resource
+            Map<String, FallbackResourceManager> domainResourceManagers = ObfuscationReflectionHelper.getPrivateValue(
+                    SimpleReloadableResourceManager.class,
+                    resourceManager,
+                    "field_110548_a" // field_110548_a domainResourceManagers
+            );
+            FallbackResourceManager modManager = domainResourceManagers.get(LibModInfo.ID);
+            if (modManager != null) {
+                List<IResourcePack> resourcePacks = ObfuscationReflectionHelper.getPrivateValue(
+                        FallbackResourceManager.class,
+                        modManager,
+                        "field_110540_a" // field_110540_a resourcePacks
+                );
+                CustomResourcePack customPack = new CustomResourcePack(location, texture);
+                if (!resourcePacks.contains(customPack)) {
+                    resourcePacks.add(customPack);
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private class CustomResourcePack implements IResourcePack {
+        private final ResourceLocation textureLocation;
+        private final byte[] textureData;
+
+        public CustomResourcePack(ResourceLocation location, BufferedImage image) {
+            this.textureLocation = location;
+            this.textureData = imageToByteArray(image);
+        }
+
+        private byte[] imageToByteArray(BufferedImage image) {
+            try {
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                ImageIO.write(image, "PNG", baos);
+                return baos.toByteArray();
+            } catch (IOException e) {
+                e.printStackTrace();
+                return new byte[0];
+            }
+        }
+
+        @Override
+        public InputStream getInputStream(ResourceLocation location) throws IOException {
+            if (location.equals(textureLocation)) {
+                return new ByteArrayInputStream(textureData);
+            }
+            throw new FileNotFoundException(location.toString());
+        }
+
+        @Override
+        public boolean resourceExists(ResourceLocation location) {
+            return location.equals(textureLocation);
+        }
+
+        @Override
+        public Set<String> getResourceDomains() {
+            return Collections.singleton(LibModInfo.ID);
+        }
+
+        @Override
+        public <T extends IMetadataSection> T getPackMetadata(MetadataSerializer metadataSerializer, String metadataSectionName) throws IOException {
+            return null;
+        }
+
+        @Override
+        public BufferedImage getPackImage() throws IOException {
+            return null;
+        }
+
+        @Override
+        public String getPackName() {
+            return LibModInfo.ID + "_dynamic_textures";
         }
     }
 }


### PR DESCRIPTION
I've noticed that the generated texture of the skin is only dynamically generated and thus innaccessible in other mods. This create weird bugs.

The following code should be simple: it takes the location of the skin of the player and attempts to retrieve a BufferedImage associated with the ResourceLocation.
The ResourceLocation is something along the lines of `armourers_workshop:[hash]`
And it just throws an exception, because the resource is not actually accessible, as it was only dynamically generated and never uploaded to the resource location management system of minecraft.
```java
public static void onRenderPreLow(RenderPlayerEvent.Pre event) {
    if (!(event.getEntityPlayer() instanceof AbstractClientPlayer)) {
        return;
    }
    AbstractClientPlayer player = (AbstractClientPlayer) event.getEntityPlayer();
    NetworkPlayerInfo playerInfo = Minecraft.getMinecraft().getConnection().getPlayerInfo(player.getUniqueID());

    if (playerInfo != null) {
        // Save the current skin texture
        BufferedImage armourerTexture = getBufferedImageSkin(player.getLocationSkin()); // throws exception
    }
}

private static BufferedImage getBufferedImageSkin(ResourceLocation resourceLocation) {
    Minecraft mc = Minecraft.getMinecraft();
    BufferedImage bufferedImage = null;
    InputStream inputStream = null;

    try {
        ITextureObject skintex = mc.getTextureManager().getTexture(resourceLocation);
        if (skintex instanceof ThreadDownloadImageData) {
            ThreadDownloadImageData imageData = (ThreadDownloadImageData)skintex;
            bufferedImage  = ObfuscationReflectionHelper.getPrivateValue(ThreadDownloadImageData.class, imageData, "bufferedImage", "field_110560_d", "bpr.h");
        } else {
            inputStream = Minecraft.getMinecraft().getResourceManager().getResource(resourceLocation).getInputStream();
            bufferedImage = ImageIO.read(inputStream);
        }
    } catch (IOException e) {
        e.printStackTrace();
    } finally {
        IOUtils.closeQuietly(inputStream);
    }

    return bufferedImage;
}
```

My PR fixes this by injecting the newly created ResourceLocation into the management system.