### PR TITLE
Update compatability for Sophisticated Backpacks to v 3.25.44

### DIFF
--- a/versions/library/fabric/src/main/java/moe/plushie/armourers_workshop/compat/fabric/mixin/backpack/FabricSophisticatedBackpackRendererMixin.java
+++ b/versions/library/fabric/src/main/java/moe/plushie/armourers_workshop/compat/fabric/mixin/backpack/FabricSophisticatedBackpackRendererMixin.java
@@ -10,7 +10,6 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 import net.p3pp3rf1y.sophisticatedbackpacks.client.render.BackpackLayerRenderer;
-import net.p3pp3rf1y.sophisticatedbackpacks.client.render.IBackpackModel;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
@@ -24,7 +23,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class FabricSophisticatedBackpackRendererMixin {
 
     @Inject(method = "renderBackpack", at = @At("HEAD"), cancellable = true, remap = false, require = 0)
-    private static void aw2$renderBackpack(EntityModel<?> parentModel, LivingEntity livingEntity, PoseStack matrixStack, MultiBufferSource buffer, int packedLight, ItemStack backpack, boolean wearsArmor, IBackpackModel model, CallbackInfo ci) {
+    private static void aw2$renderBackpack(EntityModel<?> parentModel, LivingEntity livingEntity, PoseStack matrixStack, MultiBufferSource buffer, int packedLight, ItemStack backpack, boolean wearsArmor, CallbackInfo ci) {
         var renderData = EntityRenderData.of(livingEntity);
         if (renderData != null && renderData.overriddenManager().contains(SkinProperty.OVERRIDE_MODEL_BACKPACK)) {
             ci.cancel();

--- a/versions/library/forge/src/main/java/moe/plushie/armourers_workshop/compat/forge/mixin/backpack/ForgeSophisticatedBackpackRendererMixin.java
+++ b/versions/library/forge/src/main/java/moe/plushie/armourers_workshop/compat/forge/mixin/backpack/ForgeSophisticatedBackpackRendererMixin.java
@@ -10,7 +10,6 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 import net.p3pp3rf1y.sophisticatedbackpacks.client.render.BackpackLayerRenderer;
-import net.p3pp3rf1y.sophisticatedbackpacks.client.render.IBackpackModel;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
@@ -24,7 +23,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class ForgeSophisticatedBackpackRendererMixin {
 
     @Inject(method = "renderBackpack", at = @At("HEAD"), cancellable = true, remap = false, require = 0)
-    private static void aw2$renderBackpack(EntityModel<?> parentModel, LivingEntity livingEntity, PoseStack matrixStack, MultiBufferSource buffer, int packedLight, ItemStack backpack, boolean wearsArmor, IBackpackModel model, CallbackInfo ci) {
+    private static void aw2$renderBackpack(EntityModel<?> parentModel, LivingEntity livingEntity, PoseStack matrixStack, MultiBufferSource buffer, int packedLight, ItemStack backpack, boolean wearsArmor, CallbackInfo ci) {
         var renderData = EntityRenderData.of(livingEntity);
         if (renderData != null && renderData.overriddenManager().contains(SkinProperty.OVERRIDE_MODEL_BACKPACK)) {
             ci.cancel();


### PR DESCRIPTION
## Fix Sophisticated Backpacks compatibility crash (SB 3.25.x)                                                                                                                            
           
  ### Problem                                                                                                                                                                               
   
  Armourer's Workshop fails to load alongside Sophisticated Backpacks 3.25.x with the following error:                                                                                      
           
  MixinApplyError: Mixin [armourersworkshop-compatibility-forge-mixins.json:backpack/ForgeSophisticatedBackpackRendererMixin] FAILED during APPLY                                           
  ClassMetadataNotFoundException: net.p3pp3rf1y.sophisticatedbackpacks.client.render.IBackpackModel
                                                                                                                                                                                            
  This crashes the game at startup — the mod loading phase, before the main menu appears.
                                                                                                                                                                                            
  ### Root Cause
                                                                                                                                                                                            
  SB 3.25.0 removed `IBackpackModel` from the `BackpackLayerRenderer.renderBackpack()` signature:                                                                                           
   
  ```java                                                                                                                                                                                   
  // SB < 3.25 — old signature
  static void renderBackpack(EntityModel, LivingEntity, PoseStack, MultiBufferSource, int, ItemStack, boolean, IBackpackModel)                                                              
                                                                                                                                                                                            
  // SB ≥ 3.25 — new signature                                                                                                                                                              
  static void renderBackpack(EntityModel, LivingEntity, PoseStack, MultiBufferSource, int, ItemStack, boolean)
```                                                                              
                                                                                                                                                                                            
  The Mixin handler method must mirror the target method's descriptor exactly (with CallbackInfo appended). With IBackpackModel gone from SB, the class no longer exists on the runtime     
  classpath. The Mixin processor attempts to resolve it during descriptor parsing — before even checking require = 0 — and throws ClassMetadataNotFoundException, crashing the game.        
                                                                                                                                                                                            
###  Fix      

  Remove the IBackpackModel parameter from the handler signatures in both the Forge and Fabric mixins so the descriptor matches the current SB API.                                         
   
###  Affected files:                                                                                                                                                                           
  - versions/library/forge/src/main/java/.../backpack/ForgeSophisticatedBackpackRendererMixin.java
  - versions/library/fabric/src/main/java/.../backpack/FabricSophisticatedBackpackRendererMixin.java                                                                                        
                                                                                                    
###  Tested Against                                                                                                                                                                            
                                                                                                                                                                                            
  - Sophisticated Backpacks 1.21.1-3.25.44                                                                                                                                                  
  - NeoForge 21.1.228 / 21.1.229  